### PR TITLE
Adds null checks to prevent crashes

### DIFF
--- a/addons/timers/buffs.lua
+++ b/addons/timers/buffs.lua
@@ -383,6 +383,10 @@ local function HandleAction(act)
 
     if not party then return end
 
+    if not act then return end
+    if not act.targets[1] then return end
+    if not act.targets[1].actions[1] then return end
+    if not act.targets[1].actions[1].message then return end
     local message = act.targets[1].actions[1].message
 
     local serverId = party:GetMemberServerId(0)
@@ -582,7 +586,9 @@ local function UpdateBuffs(timers)
 
                 local timer_name = v.name
                 if (t_entity and t_entity.ServerId) ~= (a_entity and a_entity.ServerId) then
-                    timer_name = ("%s (%s)"):fmt(v.name, t_entity.Name)
+                    local entity_name = "Unknown"
+                    if (t_entity and t_entity.Name) then entity_name = t_entity.Name end
+                    timer_name = ("%s (%s)"):fmt(v.name, entity_name)
                 end
 
                 local diff = ((ashita.time.clock()['ms'] - v.o_time) / 1000.0) * 60.0

--- a/addons/timers/debuffs.lua
+++ b/addons/timers/debuffs.lua
@@ -120,6 +120,11 @@ local function ApplyDebuff(target, effect, spell, actor, type, param)
 end
 
 local function HandleAction(act)
+
+    if not act then return end
+    if not act.targets[1] then return end
+    if not act.targets[1].actions[1] then return end
+    if not act.targets[1].actions[1].message then return end
     local message = act.targets[1].actions[1].message
 
     if not ActionIsLocal(act.actor_id) then return end


### PR DESCRIPTION
Was experiencing crashes on HorizonXI. These null checks prevent it from crashing, but they might have unintended consequences? There may be a better way to null check that hash instead using 4 if statements but that was at least safe.